### PR TITLE
Check imag array length in fft64

### DIFF
--- a/src/main/java/com/fft/optimized/FFTOptimized64.java
+++ b/src/main/java/com/fft/optimized/FFTOptimized64.java
@@ -97,6 +97,9 @@ public class FFTOptimized64 implements FFT {
         if (inputReal.length != SIZE) {
             throw new IllegalArgumentException("Input arrays must be of length " + SIZE);
         }
+        if (inputImag.length != SIZE) {
+            throw new IllegalArgumentException("Input arrays must be of length " + SIZE);
+        }
 
         // Delegate to the optimized utility implementation
         return OptimizedFFTUtils.fft64(inputReal, inputImag, forward);


### PR DESCRIPTION
## Summary
- validate `inputImag` length in `FFTOptimized64.fft64`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684019104798832ea4dad4c4da366e5a

## Summary by Sourcery

Bug Fixes:
- Throw IllegalArgumentException when inputImag length does not match the expected SIZE