### PR TITLE
Add static fft64 length validation tests

### DIFF
--- a/src/test/java/com/fft/optimized/FFTOptimized64Test.java
+++ b/src/test/java/com/fft/optimized/FFTOptimized64Test.java
@@ -356,4 +356,34 @@ class FFTOptimized64Test {
             }
         }
     }
+
+    @Nested
+    @DisplayName("Static fft64() Method Tests")
+    class StaticFFT64MethodTests {
+
+        @Test
+        @DisplayName("Should throw if imaginary array length is incorrect")
+        void shouldThrowForWrongImagLength() {
+            double[] real = new double[SIZE];
+            double[] imagWrong = new double[SIZE - 1];
+
+            assertThatThrownBy(() -> FFTOptimized64.fft64(real, imagWrong, true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("64");
+        }
+
+        @Test
+        @DisplayName("Should transform with correct array lengths")
+        void shouldTransformWithCorrectArrayLengths() {
+            double[] real = new double[SIZE];
+            double[] imag = new double[SIZE];
+
+            assertThatCode(() -> FFTOptimized64.fft64(real, imag, true))
+                .doesNotThrowAnyException();
+
+            double[] result = FFTOptimized64.fft64(real, imag, true);
+            assertThat(result).isNotNull();
+            assertThat(result).hasSize(SIZE * 2);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- test FFTOptimized64.fft64 with bad imaginary array length
- ensure fft64 works with correct array length

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684028af7e88832ea49772c20de96018

## Summary by Sourcery

Add static fft64 method tests to validate argument length checking and ensure correct operation.

Tests:
- Add test to verify fft64 throws IllegalArgumentException when the imaginary array length is incorrect
- Add test to verify fft64 executes without error and returns an array of size 2×N for correct input lengths