### PR TITLE
Update supported FFT sizes to 65536

### DIFF
--- a/src/main/java/com/fft/factory/DefaultFFTFactory.java
+++ b/src/main/java/com/fft/factory/DefaultFFTFactory.java
@@ -107,12 +107,16 @@ public class DefaultFFTFactory implements FFTFactory {
     @Override
     public List<Integer> getSupportedSizes() {
         Set<Integer> sizes = new TreeSet<>(implementations.keySet());
-        
-        // Add common power-of-2 sizes that are supported by fallback
-        for (int size = 2; size <= 8192; size *= 2) {
-            sizes.add(size);
+
+        // Dynamically include power-of-two sizes up to 65536
+        for (int size = 2; size > 0 && size <= 65536; size *= 2) {
+            if (supportsSize(size)) {
+                sizes.add(size);
+            } else {
+                break;
+            }
         }
-        
+
         return new ArrayList<>(sizes);
     }
     

--- a/src/test/java/com/fft/factory/DefaultFFTFactoryTest.java
+++ b/src/test/java/com/fft/factory/DefaultFFTFactoryTest.java
@@ -76,6 +76,9 @@ class DefaultFFTFactoryTest {
         assertThat(factory.supportsSize(2048)).isTrue();
         assertThat(factory.supportsSize(4096)).isTrue();
         assertThat(factory.supportsSize(8192)).isTrue();
+        assertThat(factory.supportsSize(16384)).isTrue();
+        assertThat(factory.supportsSize(32768)).isTrue();
+        assertThat(factory.supportsSize(65536)).isTrue();
         
         assertThat(factory.supportsSize(7)).isFalse();
         assertThat(factory.supportsSize(15)).isFalse();
@@ -87,7 +90,8 @@ class DefaultFFTFactoryTest {
     void testGetSupportedSizes() {
         var sizes = factory.getSupportedSizes();
         
-        assertThat(sizes).contains(2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192);
+        assertThat(sizes).contains(2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192,
+                                  16384, 32768, 65536);
         assertThat(sizes).isSorted();
         assertThat(sizes).doesNotContain(7, 15, 100);
     }

--- a/src/test/java/com/fft/utils/FFTUtilsTest.java
+++ b/src/test/java/com/fft/utils/FFTUtilsTest.java
@@ -198,7 +198,8 @@ class FFTUtilsTest {
     void testGetSupportedSizes() {
         List<Integer> sizes = FFTUtils.getSupportedSizes();
         
-        assertThat(sizes).contains(2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192);
+        assertThat(sizes).contains(2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192,
+                                  16384, 32768, 65536);
         assertThat(sizes).isSorted();
     }
     


### PR DESCRIPTION
## Summary
- extend `DefaultFFTFactory.getSupportedSizes()` to return sizes up to 65536
- test new sizes in `DefaultFFTFactoryTest`
- test new sizes via utility API in `FFTUtilsTest`

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-failsafe-plugin:3.0.0-M9 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68414fcc71ec832ebcb5da3da2e851f5

## Summary by Sourcery

Extend FFT support to include power-of-two sizes up to 65536 and update related tests

Enhancements:
- Expand getSupportedSizes to dynamically include power-of-two sizes up to 65536

Tests:
- Add assertions for 16384, 32768, and 65536 in DefaultFFTFactoryTest
- Add assertions for 16384, 32768, and 65536 in FFTUtilsTest