### PR TITLE
Add input length checks to optimized FFT methods

### DIFF
--- a/src/main/java/com/fft/optimized/FFTOptimized1024.java
+++ b/src/main/java/com/fft/optimized/FFTOptimized1024.java
@@ -96,6 +96,9 @@ public class FFTOptimized1024 implements FFT {
         if (inputReal.length != SIZE) {
             throw new IllegalArgumentException("Input arrays must be of length " + SIZE);
         }
+        if (inputImag.length != SIZE) {
+            throw new IllegalArgumentException("Input arrays must be of length " + SIZE);
+        }
         
         // Delegate to the original optimized implementation
         try {

--- a/src/main/java/com/fft/optimized/FFTOptimized128.java
+++ b/src/main/java/com/fft/optimized/FFTOptimized128.java
@@ -96,6 +96,9 @@ public class FFTOptimized128 implements FFT {
         if (inputReal.length != SIZE) {
             throw new IllegalArgumentException("Input arrays must be of length " + SIZE);
         }
+        if (inputImag.length != SIZE) {
+            throw new IllegalArgumentException("Input arrays must be of length " + SIZE);
+        }
         
         // Delegate to the original optimized implementation, fallback to base if not available
         try {

--- a/src/main/java/com/fft/optimized/FFTOptimized16384.java
+++ b/src/main/java/com/fft/optimized/FFTOptimized16384.java
@@ -95,6 +95,9 @@ public class FFTOptimized16384 implements FFT {
         if (inputReal.length != SIZE) {
             throw new IllegalArgumentException("Input arrays must be of length " + SIZE);
         }
+        if (inputImag.length != SIZE) {
+            throw new IllegalArgumentException("Input arrays must be of length " + SIZE);
+        }
         
         // Use radix-2 decomposition: 16384 = 2 * 8192
         double[] evenReal = new double[8192];

--- a/src/main/java/com/fft/optimized/FFTOptimized2048.java
+++ b/src/main/java/com/fft/optimized/FFTOptimized2048.java
@@ -96,6 +96,9 @@ public class FFTOptimized2048 implements FFT {
         if (inputReal.length != SIZE) {
             throw new IllegalArgumentException("Input arrays must be of length " + SIZE);
         }
+        if (inputImag.length != SIZE) {
+            throw new IllegalArgumentException("Input arrays must be of length " + SIZE);
+        }
         
         // Delegate to the original optimized implementation
         try {

--- a/src/main/java/com/fft/optimized/FFTOptimized256.java
+++ b/src/main/java/com/fft/optimized/FFTOptimized256.java
@@ -96,6 +96,9 @@ public class FFTOptimized256 implements FFT {
         if (inputReal.length != SIZE) {
             throw new IllegalArgumentException("Input arrays must be of length " + SIZE);
         }
+        if (inputImag.length != SIZE) {
+            throw new IllegalArgumentException("Input arrays must be of length " + SIZE);
+        }
         
         // Delegate to the original optimized implementation
         try {

--- a/src/main/java/com/fft/optimized/FFTOptimized32.java
+++ b/src/main/java/com/fft/optimized/FFTOptimized32.java
@@ -110,6 +110,9 @@ public class FFTOptimized32 implements FFT {
         if (inputReal.length != OPTIMIZED_SIZE) {
             throw new IllegalArgumentException("Input arrays must be of length " + OPTIMIZED_SIZE);
         }
+        if (inputImag.length != OPTIMIZED_SIZE) {
+            throw new IllegalArgumentException("Input arrays must be of length " + OPTIMIZED_SIZE);
+        }
         
         // Delegate to the optimized utility implementation
         return OptimizedFFTUtils.fft32(inputReal, inputImag, forward);

--- a/src/main/java/com/fft/optimized/FFTOptimized32768.java
+++ b/src/main/java/com/fft/optimized/FFTOptimized32768.java
@@ -96,6 +96,9 @@ public class FFTOptimized32768 implements FFT {
         if (inputReal.length != SIZE) {
             throw new IllegalArgumentException("Input arrays must be of length " + SIZE);
         }
+        if (inputImag.length != SIZE) {
+            throw new IllegalArgumentException("Input arrays must be of length " + SIZE);
+        }
         
         // Use radix-4 decomposition: 32768 = 4 * 8192
         double[][] fourReal = new double[4][8192];

--- a/src/main/java/com/fft/optimized/FFTOptimized4096.java
+++ b/src/main/java/com/fft/optimized/FFTOptimized4096.java
@@ -96,6 +96,9 @@ public class FFTOptimized4096 implements FFT {
         if (inputReal.length != SIZE) {
             throw new IllegalArgumentException("Input arrays must be of length " + SIZE);
         }
+        if (inputImag.length != SIZE) {
+            throw new IllegalArgumentException("Input arrays must be of length " + SIZE);
+        }
         
         // Delegate to the original optimized implementation
         try {

--- a/src/main/java/com/fft/optimized/FFTOptimized512.java
+++ b/src/main/java/com/fft/optimized/FFTOptimized512.java
@@ -96,6 +96,9 @@ public class FFTOptimized512 implements FFT {
         if (inputReal.length != SIZE) {
             throw new IllegalArgumentException("Input arrays must be of length " + SIZE);
         }
+        if (inputImag.length != SIZE) {
+            throw new IllegalArgumentException("Input arrays must be of length " + SIZE);
+        }
         
         // Delegate to the original optimized implementation
         try {

--- a/src/main/java/com/fft/optimized/FFTOptimized65536.java
+++ b/src/main/java/com/fft/optimized/FFTOptimized65536.java
@@ -100,6 +100,9 @@ public class FFTOptimized65536 implements FFT {
         if (inputReal.length != SIZE) {
             throw new IllegalArgumentException("Input arrays must be of length " + SIZE);
         }
+        if (inputImag.length != SIZE) {
+            throw new IllegalArgumentException("Input arrays must be of length " + SIZE);
+        }
         
         // Use radix-8 decomposition: 65536 = 8 * 8192
         double[][] eightReal = new double[8][8192];

--- a/src/main/java/com/fft/optimized/FFTOptimized8192.java
+++ b/src/main/java/com/fft/optimized/FFTOptimized8192.java
@@ -96,6 +96,9 @@ public class FFTOptimized8192 implements FFT {
         if (inputReal.length != SIZE) {
             throw new IllegalArgumentException("Input arrays must be of length " + SIZE);
         }
+        if (inputImag.length != SIZE) {
+            throw new IllegalArgumentException("Input arrays must be of length " + SIZE);
+        }
         
         // Delegate to the original optimized implementation
         try {


### PR DESCRIPTION
## Summary
- validate imaginary input length in optimized FFT static methods

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_68414faf1000832eb44d17d8a053c5b3

## Summary by Sourcery

Bug Fixes:
- Add missing length check for the imaginary input array in each optimized FFT static method, throwing IllegalArgumentException if its length is incorrect.