### PR TITLE
Add coverage for large optimized FFT sizes

### DIFF
--- a/src/test/java/com/fft/optimized/FFTOptimized1024Test.java
+++ b/src/test/java/com/fft/optimized/FFTOptimized1024Test.java
@@ -1,0 +1,71 @@
+package com.fft.optimized;
+
+import com.fft.core.FFTBase;
+import com.fft.core.FFTResult;
+import com.fft.utils.FFTUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("FFTOptimized1024 Tests")
+class FFTOptimized1024Test {
+
+    private FFTOptimized1024 fft;
+    private FFTBase reference;
+    private static final int SIZE = 1024;
+    private static final double TOLERANCE = 1e-10;
+
+    @BeforeEach
+    void setUp() {
+        fft = new FFTOptimized1024();
+        reference = new FFTBase();
+    }
+
+    @Test
+    @DisplayName("Should return correct supported size")
+    void shouldReturnCorrectSupportedSize() {
+        assertThat(fft.getSupportedSize()).isEqualTo(SIZE);
+        assertThat(fft.supportsSize(SIZE)).isTrue();
+        assertThat(fft.supportsSize(512)).isFalse();
+        assertThat(fft.supportsSize(2048)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should correctly transform impulse function")
+    void shouldCorrectlyTransformImpulseFunction() {
+        double[] real = new double[SIZE];
+        double[] imag = new double[SIZE];
+        real[0] = 1.0;
+
+        FFTResult result = fft.transform(real, imag, true);
+        double[] output = result.getInterleavedResult();
+
+        double expectedValue = 1.0 / Math.sqrt(SIZE);
+        for (int i = 0; i < SIZE; i++) {
+            assertThat(output[2 * i]).isCloseTo(expectedValue, within(TOLERANCE));
+            assertThat(output[2 * i + 1]).isCloseTo(0.0, within(TOLERANCE));
+        }
+    }
+
+    @Test
+    @DisplayName("Should match FFTBase results")
+    void shouldMatchFFTBaseResults() {
+        double[] real = FFTUtils.generateTestSignal(SIZE, "random");
+        double[] imag = new double[SIZE];
+
+        FFTResult expected = reference.transform(real.clone(), imag.clone(), true);
+        FFTResult actual = fft.transform(real.clone(), imag.clone(), true);
+
+        double[] expReal = expected.getRealParts();
+        double[] expImag = expected.getImaginaryParts();
+        double[] actReal = actual.getRealParts();
+        double[] actImag = actual.getImaginaryParts();
+
+        for (int i = 0; i < SIZE; i++) {
+            assertThat(actReal[i]).isCloseTo(expReal[i], within(TOLERANCE));
+            assertThat(actImag[i]).isCloseTo(expImag[i], within(TOLERANCE));
+        }
+    }
+}

--- a/src/test/java/com/fft/optimized/FFTOptimized128Test.java
+++ b/src/test/java/com/fft/optimized/FFTOptimized128Test.java
@@ -2,6 +2,7 @@ package com.fft.optimized;
 
 import com.fft.core.FFTResult;
 import com.fft.utils.FFTUtils;
+import com.fft.core.FFTBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
@@ -93,5 +94,25 @@ class FFTOptimized128Test {
         }
         
         assertThat(outputEnergy).isCloseTo(inputEnergy, within(TOLERANCE));
+    }
+    @Test
+    @DisplayName("Should match FFTBase results")
+    void shouldMatchFFTBaseResults() {
+        FFTBase reference = new FFTBase();
+        double[] real = FFTUtils.generateTestSignal(SIZE, "random");
+        double[] imag = new double[SIZE];
+
+        FFTResult expected = reference.transform(real.clone(), imag.clone(), true);
+        FFTResult actual = fft.transform(real.clone(), imag.clone(), true);
+
+        double[] expectedReal = expected.getRealParts();
+        double[] expectedImag = expected.getImaginaryParts();
+        double[] actualReal = actual.getRealParts();
+        double[] actualImag = actual.getImaginaryParts();
+
+        for (int i = 0; i < SIZE; i++) {
+            assertThat(actualReal[i]).isCloseTo(expectedReal[i], within(TOLERANCE));
+            assertThat(actualImag[i]).isCloseTo(expectedImag[i], within(TOLERANCE));
+        }
     }
 }

--- a/src/test/java/com/fft/optimized/FFTOptimized256Test.java
+++ b/src/test/java/com/fft/optimized/FFTOptimized256Test.java
@@ -1,0 +1,71 @@
+package com.fft.optimized;
+
+import com.fft.core.FFTBase;
+import com.fft.core.FFTResult;
+import com.fft.utils.FFTUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("FFTOptimized256 Tests")
+class FFTOptimized256Test {
+
+    private FFTOptimized256 fft;
+    private FFTBase reference;
+    private static final int SIZE = 256;
+    private static final double TOLERANCE = 1e-10;
+
+    @BeforeEach
+    void setUp() {
+        fft = new FFTOptimized256();
+        reference = new FFTBase();
+    }
+
+    @Test
+    @DisplayName("Should return correct supported size")
+    void shouldReturnCorrectSupportedSize() {
+        assertThat(fft.getSupportedSize()).isEqualTo(SIZE);
+        assertThat(fft.supportsSize(SIZE)).isTrue();
+        assertThat(fft.supportsSize(128)).isFalse();
+        assertThat(fft.supportsSize(512)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should correctly transform impulse function")
+    void shouldCorrectlyTransformImpulseFunction() {
+        double[] real = new double[SIZE];
+        double[] imag = new double[SIZE];
+        real[0] = 1.0;
+
+        FFTResult result = fft.transform(real, imag, true);
+        double[] output = result.getInterleavedResult();
+
+        double expectedValue = 1.0 / Math.sqrt(SIZE);
+        for (int i = 0; i < SIZE; i++) {
+            assertThat(output[2 * i]).isCloseTo(expectedValue, within(TOLERANCE));
+            assertThat(output[2 * i + 1]).isCloseTo(0.0, within(TOLERANCE));
+        }
+    }
+
+    @Test
+    @DisplayName("Should match FFTBase results")
+    void shouldMatchFFTBaseResults() {
+        double[] real = FFTUtils.generateTestSignal(SIZE, "random");
+        double[] imag = new double[SIZE];
+
+        FFTResult expected = reference.transform(real.clone(), imag.clone(), true);
+        FFTResult actual = fft.transform(real.clone(), imag.clone(), true);
+
+        double[] expReal = expected.getRealParts();
+        double[] expImag = expected.getImaginaryParts();
+        double[] actReal = actual.getRealParts();
+        double[] actImag = actual.getImaginaryParts();
+
+        for (int i = 0; i < SIZE; i++) {
+            assertThat(actReal[i]).isCloseTo(expReal[i], within(TOLERANCE));
+            assertThat(actImag[i]).isCloseTo(expImag[i], within(TOLERANCE));
+        }
+    }
+}

--- a/src/test/java/com/fft/optimized/FFTOptimized512Test.java
+++ b/src/test/java/com/fft/optimized/FFTOptimized512Test.java
@@ -1,0 +1,71 @@
+package com.fft.optimized;
+
+import com.fft.core.FFTBase;
+import com.fft.core.FFTResult;
+import com.fft.utils.FFTUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("FFTOptimized512 Tests")
+class FFTOptimized512Test {
+
+    private FFTOptimized512 fft;
+    private FFTBase reference;
+    private static final int SIZE = 512;
+    private static final double TOLERANCE = 1e-10;
+
+    @BeforeEach
+    void setUp() {
+        fft = new FFTOptimized512();
+        reference = new FFTBase();
+    }
+
+    @Test
+    @DisplayName("Should return correct supported size")
+    void shouldReturnCorrectSupportedSize() {
+        assertThat(fft.getSupportedSize()).isEqualTo(SIZE);
+        assertThat(fft.supportsSize(SIZE)).isTrue();
+        assertThat(fft.supportsSize(256)).isFalse();
+        assertThat(fft.supportsSize(1024)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should correctly transform impulse function")
+    void shouldCorrectlyTransformImpulseFunction() {
+        double[] real = new double[SIZE];
+        double[] imag = new double[SIZE];
+        real[0] = 1.0;
+
+        FFTResult result = fft.transform(real, imag, true);
+        double[] output = result.getInterleavedResult();
+
+        double expectedValue = 1.0 / Math.sqrt(SIZE);
+        for (int i = 0; i < SIZE; i++) {
+            assertThat(output[2 * i]).isCloseTo(expectedValue, within(TOLERANCE));
+            assertThat(output[2 * i + 1]).isCloseTo(0.0, within(TOLERANCE));
+        }
+    }
+
+    @Test
+    @DisplayName("Should match FFTBase results")
+    void shouldMatchFFTBaseResults() {
+        double[] real = FFTUtils.generateTestSignal(SIZE, "random");
+        double[] imag = new double[SIZE];
+
+        FFTResult expected = reference.transform(real.clone(), imag.clone(), true);
+        FFTResult actual = fft.transform(real.clone(), imag.clone(), true);
+
+        double[] expReal = expected.getRealParts();
+        double[] expImag = expected.getImaginaryParts();
+        double[] actReal = actual.getRealParts();
+        double[] actImag = actual.getImaginaryParts();
+
+        for (int i = 0; i < SIZE; i++) {
+            assertThat(actReal[i]).isCloseTo(expReal[i], within(TOLERANCE));
+            assertThat(actImag[i]).isCloseTo(expImag[i], within(TOLERANCE));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- expand optimized test coverage to 256, 512 and 1024
- verify optimized 128 output against FFTBase

## Testing
- `mvn -q test` *(failed: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_68415a6c0ea8832e969efcd8e42276f5

## Summary by Sourcery

Add comprehensive tests for large optimized FFT sizes and ensure optimized implementation matches the reference FFTBase output

Tests:
- Add FFTOptimized256, FFTOptimized512, and FFTOptimized1024 test classes verifying supported size, impulse transformation, and matching FFTBase results
- Add a reference-comparison test to FFTOptimized128Test to validate optimized 128 output against FFTBase