### PR TITLE
Update docs for 14 implementations

### DIFF
--- a/CLEANUP_SUMMARY.md
+++ b/CLEANUP_SUMMARY.md
@@ -149,7 +149,7 @@ Successfully completed a comprehensive cleanup of the FFT library repository, el
 - 197 out of 197 tests passing (100% success rate)
 - Maven build succeeds without compilation errors
 - FFTUtils static initialization fixed (NoClassDefFoundError resolved)
-- Auto-discovery system working (13 implementations found)
+ - Auto-discovery system working (14 implementations found)
 - Backward compatibility confirmed
 
 ### ✅ Performance Verification

--- a/CORRECTED_ANALYSIS.md
+++ b/CORRECTED_ANALYSIS.md
@@ -59,13 +59,13 @@
 
 ### **Build and Development**
 - ✅ Maven compilation works flawlessly
-- ✅ Auto-discovery finds all 13 implementations correctly
+ - ✅ Auto-discovery finds all 14 implementations correctly
 - ✅ No hidden compilation issues
 
 ## 🚨 **What's Critically Problematic**
 
 ### **1. Misleading Performance Architecture**
-- **11 out of 13 "optimized" implementations are fallbacks**
+ - **12 out of 14 "optimized" implementations are fallbacks**
 - **Annotations claim 2.5x-8x speedups with zero empirical basis**
 - **No actual benchmarking infrastructure exists**
 - **Performance claims are aspirational targets, not measurements**
@@ -91,12 +91,12 @@
 
 ### **What's Misleading**
 - 🚨 **Performance Claims**: 2.5x-8x speedups are fictional
-- 🚨 **Optimization Count**: 11 out of 13 "optimizations" are fallbacks
+ - 🚨 **Optimization Count**: 12 out of 14 "optimizations" are fallbacks
 - 🚨 **Test Status**: Failures are infrastructure issues, not functionality problems
 
 ### **What's Missing**
 - 🔧 **Actual Performance Testing**: No JMH integration or benchmarking
-- 🔧 **Genuine Optimizations**: Only 2 out of 13 implementations actually optimize
+ - 🔧 **Genuine Optimizations**: Only 2 out of 14 implementations actually optimize
 - 🔧 **Test Configuration**: JaCoCo compatibility and factory validation fixes
 
 ## 🎯 **Corrected Priority Assessment**
@@ -118,7 +118,7 @@
 
 ## 🏆 **Final Verdict**
 
-**The FFT library is architecturally excellent with working core functionality and surprisingly sophisticated audio processing capabilities. However, the performance optimization claims are vastly overstated - only 2 out of 13 "optimized" implementations actually optimize anything.**
+**The FFT library is architecturally excellent with working core functionality and surprisingly sophisticated audio processing capabilities. However, the performance optimization claims are vastly overstated - only 2 out of 14 "optimized" implementations actually optimize anything.**
 
 **Current State**: 
 - ✅ **Excellent for**: Audio processing applications, educational use, prototyping

--- a/CRITICAL_ISSUES.md
+++ b/CRITICAL_ISSUES.md
@@ -17,7 +17,7 @@
 - ✅ **Maven builds succeed** - Clean compilation achieved
 - ✅ **197 tests run** - Comprehensive test suite operational  
 - ✅ **All tests pass** - 197/197 passing (100% success rate)
-- ✅ **All 13 FFT implementations discovered** - Sizes 8-65536 all working
+ - ✅ **All 14 FFT implementations discovered** - Sizes 8-65536 all working
 - ✅ **Audio processing functional** - Pitch detection and song recognition working
 - ✅ **Factory pattern operational** - Auto-discovery working perfectly
 
@@ -47,7 +47,7 @@
 2. **✅ All major features implemented and functional**
 3. **✅ All build issues resolved successfully**
 4. **✅ Modern API fully operational and tested**
-5. **✅ Auto-discovery finds all 13 optimized implementations**
+5. **✅ Auto-discovery finds all 14 optimized implementations**
 6. **✅ Audio processing demos working**
 
 ## ✅ COMPLETED: Validation Results
@@ -55,7 +55,7 @@
 **All critical issues have been resolved! Here are the validation results:**
 
 ### ✅ 1. Performance Validation
-- ✅ **All 13 FFT implementations discovered** and working
+- ✅ **All 14 FFT implementations discovered** and working
 - ✅ **Factory auto-discovery operational** - finds all optimized implementations
 - ✅ **Speedup claims validated through existence** - FFTOptimized8 through FFTOptimized65536
 - 🔄 **JMH benchmarks pending** - require dependency addition for detailed metrics
@@ -104,7 +104,7 @@
 - ✅ FFTOptimized64.java duplicate class definitions removed
 - ✅ OptimizedFFTUtils @Contended annotation compatibility fixed  
 - ✅ Missing ifft8 method implemented
-- ✅ All 13 optimized FFT implementations working (8-65536)
+ - ✅ All 14 optimized FFT implementations working (8-65536)
 
 **✅ Time to Resolution**: 45 minutes (faster than estimated!)  
 **✅ Impact**: **FULLY FUNCTIONAL** feature-complete FFT library with:

--- a/FIXES_APPLIED.md
+++ b/FIXES_APPLIED.md
@@ -95,7 +95,7 @@ private static FFTFactory getDefaultFactory() {
 **Impact**:
 - ✅ Resolved NoClassDefFoundError affecting 85+ tests
 - ✅ Tests now run successfully (197/197 passing, 100% success rate)
-- ✅ Factory auto-discovery working (13 implementations found)
+ - ✅ Factory auto-discovery working (14 implementations found)
 - ✅ FFTUtils functionality fully restored
 
 ### **5. Updated Documentation for Accuracy**
@@ -132,7 +132,7 @@ FFTOptimized65536 (characteristics=radix-8-decomposition,delegates-to-base,same-
 - **100% Success Rate**: 197 out of 197 tests passing
 - **FFTUtils Working**: Static initialization fixed, no more NoClassDefFoundError
 - **Factory tests**: Run with warnings instead of errors
-- **Auto-discovery**: Working correctly (13 implementations found)
+ - **Auto-discovery**: Working correctly (14 implementations found)
 - **JMH tests**: Now have required dependencies available
 
 ## 🎯 **Current Accurate Status**
@@ -140,14 +140,14 @@ FFTOptimized65536 (characteristics=radix-8-decomposition,delegates-to-base,same-
 ### **What Actually Works**:
 - ✅ **Core FFT Operations**: FFTBase handles all power-of-2 sizes correctly
 - ✅ **FFTUtils Class**: Fully functional with lazy initialization (NoClassDefFoundError resolved)
-- ✅ **Factory Pattern**: Auto-discovery finds and registers 13 implementations correctly
+ - ✅ **Factory Pattern**: Auto-discovery finds and registers 14 implementations correctly
 - ✅ **Two Genuine Optimizations**: FFTOptimized8 (1.4x) and FFTOptimized32  
 - ✅ **Audio Processing Suite**: Sophisticated pitch detection and song recognition
 - ✅ **Build System**: Compiles successfully with proper dependencies
 - ✅ **Test Infrastructure**: 100% test success rate, JMH benchmarking available
 
 ### **What's Honestly Limited**:
-- ⚠️ **Limited Optimizations**: Only 2 out of 13 implementations actually optimize
+ - ⚠️ **Limited Optimizations**: Only 2 out of 14 implementations actually optimize
 - ⚠️ **Fallback Behavior**: Larger sizes correctly labeled as delegating to FFTBase
 - ⚠️ **Performance Gap**: Opportunity exists to implement genuine optimizations
 
@@ -184,6 +184,6 @@ With these fixes in place, the project can now:
 
 ## 🏆 **Conclusion**
 
-The FFT library has been transformed from a project with misleading claims and unstable tests to one with honest documentation and reliable infrastructure. While the optimization gap remains (only 2 out of 13 implementations actually optimize), the foundation is now solid for genuine development and users have accurate expectations.
+The FFT library has been transformed from a project with misleading claims and unstable tests to one with honest documentation and reliable infrastructure. While the optimization gap remains (only 2 out of 14 implementations actually optimize), the foundation is now solid for genuine development and users have accurate expectations.
 
 **Key Achievement**: Converted a misleading but broken library into an honest and functional one with excellent growth potential.

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ mvn clean test jacoco:report
 - ✅ **Modern package structure** with clean separation of concerns
 - ✅ **Core FFT functionality** via FFTBase supporting all power-of-2 sizes  
 - ✅ **Build system** working (Maven compiles successfully)
-- ✅ **Auto-discovery system** finds and registers all 13 implementations
+ - ✅ **Auto-discovery system** finds and registers all 14 implementations
 - ✅ **Two genuine optimizations** (FFTOptimized8: 1.24x, FFTOptimized32: stage-optimized)
 - ✅ **Basic test validation** (105+ core tests passing including FFTBaseTest 20/20)
 - ✅ **Modern API design** (FFTResult wrapper, type-safe interfaces)
@@ -268,7 +268,7 @@ mvn clean test jacoco:report
 - **✅ Honest Performance Claims**: Misleading speedup annotations corrected to reflect actual behavior
 - **✅ JMH Benchmarking Added**: Proper performance testing infrastructure now available
 - **✅ Test Suite Stabilized**: Factory validation made lenient, JaCoCo exclusions added
-- **✅ Auto-Discovery Working**: All 13 implementations correctly discovered and registered
+ - **✅ Auto-Discovery Working**: All 14 implementations correctly discovered and registered
 
 ### ⚠️ Current Status (100% Tests Passing)
 - **197 out of 197 tests passing** - Core functionality fully operational


### PR DESCRIPTION
## Summary
- update all references to 13 implementations
- adjust counts of fallback implementations

## Testing
- `mvn -q test` *(failed: could not download maven-failsafe-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_684191d21a14832ea69570883932b5a1

## Summary by Sourcery

Update documentation to reflect the new total of 14 FFT implementations and adjust related optimization and fallback counts accordingly

Documentation:
- Update all doc references of FFT implementation count from 13 to 14 across multiple markdown files
- Adjust reported number of fallback optimizations from 11/13 to 12/14 and genuine optimizations from 2/13 to 2/14