### PR TITLE
Add JavaDoc comment for default factory method

### DIFF
--- a/src/main/java/com/fft/utils/FFTUtils.java
+++ b/src/main/java/com/fft/utils/FFTUtils.java
@@ -50,7 +50,13 @@ import com.fft.factory.FFTFactory;
 public class FFTUtils {
     
     private static volatile FFTFactory DEFAULT_FACTORY;
-    
+
+    /**
+     * Returns the default {@link FFTFactory} instance.
+     *
+     * <p>The factory is lazily created on first access using double-checked
+     * locking and reused for subsequent calls.</p>
+     */
     private static FFTFactory getDefaultFactory() {
         FFTFactory factory = DEFAULT_FACTORY;
         if (factory == null) {


### PR DESCRIPTION
## Summary
- document the lazy initialization logic in `FFTUtils.getDefaultFactory`

## Testing
- `mvn -q test` *(fails: PluginResolutionException due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6842b9c51134832ea89611590eb6ae53