### PR TITLE
Refactor performance tests to use best-of-batches measurement

### DIFF
--- a/src/test/java/com/fft/optimized/FFTPerformanceBenchmarkTest.java
+++ b/src/test/java/com/fft/optimized/FFTPerformanceBenchmarkTest.java
@@ -31,9 +31,14 @@ class FFTPerformanceBenchmarkTest {
     private FFTBase baseImplementation;
 
     // Test configuration
-    private static final int WARMUP_ITERATIONS = 50;
+    private static final int WARMUP_ITERATIONS = 2000;
     private static final int BENCHMARK_ITERATIONS = 500;
+    private static final int MEASURE_REPEATS = 5;
     private static final double TOLERANCE = 1e-10;
+
+    // Consumes transform output so the JIT cannot eliminate the benchmarked call as dead code.
+    @SuppressWarnings("unused")
+    private volatile double sink;
 
     // Sizes to benchmark
     private static final int[] SIZES = { 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536 };
@@ -119,9 +124,11 @@ class FFTPerformanceBenchmarkTest {
                     avgSpeedup, minSpeedup, maxSpeedup, speedups.size());
             System.out.println("=".repeat(80) + "\n");
 
-            // Verify that we have working implementations across the board
-            assertThat(avgSpeedup).isGreaterThan(0.1); // Implementations should not be dramatically slower
-            assertThat(minSpeedup).isGreaterThan(0.005); // All should at least run (adjusted for fast modern hardware)
+            // Only sizes with a dedicated optimized impl (8, 16) are measured here; the rest
+            // fall back to FFTBase and are skipped above. Conservative guards: optimized sizes
+            // should not regress below FFTBase. Canonical figures come from JMH.
+            assertThat(avgSpeedup).isGreaterThan(1.0);
+            assertThat(minSpeedup).isGreaterThan(0.9);
             assertThat(speedups.size()).isGreaterThanOrEqualTo(1); // Should have at least one optimized implementation
         }
 
@@ -259,15 +266,12 @@ class FFTPerformanceBenchmarkTest {
         System.out.printf("  Speedup:                  %.2fx\n", result.speedup);
         System.out.printf("  Efficiency:               %.1f%%\n", result.efficiency * 100);
 
-        // For implementations that fall back to base, speedup may not be significant
-        // Verify that the implementation at least runs correctly (adjusted for modern
-        // fast hardware)
-        assertThat(result.speedup).isGreaterThan(0.005); // At least not dramatically slower
-
-        // Log if this is likely a fallback implementation
-        if (result.speedup < 1.1) {
-            System.out.printf("  Note: Implementation likely using fallback (speedup=%.2fx)\n", result.speedup);
-        }
+        // Conservative regression guard for sizes that DO have an optimized impl (8, 16).
+        // Canonical speedup figures come from JMH; this only catches a catastrophic regression
+        // without flaking under host load.
+        assertThat(result.speedup)
+            .as("optimized size %d should beat FFTBase", size)
+            .isGreaterThan(1.1);
     }
 
     /**
@@ -277,30 +281,36 @@ class FFTPerformanceBenchmarkTest {
         double[] real = FFTUtils.generateTestSignal(size, "mixed");
         double[] imag = new double[size];
 
-        // Warmup both implementations
+        // Warmup both, consuming output so the JIT cannot dead-code-eliminate the transform.
+        double local = 0.0;
         for (int i = 0; i < WARMUP_ITERATIONS; i++) {
-            baseImplementation.transform(real, imag, true);
-            optimized.transform(real, imag, true);
+            local += baseImplementation.transform(real, imag, true).getRealAt(0);
+            local += optimized.transform(real, imag, true).getRealAt(0);
         }
 
-        // Benchmark base implementation
-        long baseStartTime = System.nanoTime();
-        for (int i = 0; i < BENCHMARK_ITERATIONS; i++) {
-            baseImplementation.transform(real, imag, true);
-        }
-        long baseEndTime = System.nanoTime();
-        double baseTimeNs = (double) (baseEndTime - baseStartTime) / BENCHMARK_ITERATIONS;
+        // Best-of-batches: time whole batches and keep the fastest, rejecting GC/scheduling
+        // outliers so the ratio is stable instead of flaking under host load.
+        long bestBase = Long.MAX_VALUE;
+        long bestOpt = Long.MAX_VALUE;
+        for (int rep = 0; rep < MEASURE_REPEATS; rep++) {
+            long t0 = System.nanoTime();
+            for (int i = 0; i < BENCHMARK_ITERATIONS; i++) {
+                local += baseImplementation.transform(real, imag, true).getRealAt(0);
+            }
+            bestBase = Math.min(bestBase, System.nanoTime() - t0);
 
-        // Benchmark optimized implementation
-        long optimizedStartTime = System.nanoTime();
-        for (int i = 0; i < BENCHMARK_ITERATIONS; i++) {
-            optimized.transform(real, imag, true);
+            long t1 = System.nanoTime();
+            for (int i = 0; i < BENCHMARK_ITERATIONS; i++) {
+                local += optimized.transform(real, imag, true).getRealAt(0);
+            }
+            bestOpt = Math.min(bestOpt, System.nanoTime() - t1);
         }
-        long optimizedEndTime = System.nanoTime();
-        double optimizedTimeNs = (double) (optimizedEndTime - optimizedStartTime) / BENCHMARK_ITERATIONS;
+        sink = local;
 
+        double baseTimeNs = (double) bestBase / BENCHMARK_ITERATIONS;
+        double optimizedTimeNs = (double) bestOpt / BENCHMARK_ITERATIONS;
         double speedup = baseTimeNs / optimizedTimeNs;
-        double efficiency = (speedup - 1.0) / speedup; // Efficiency as fraction of theoretical maximum
+        double efficiency = (speedup - 1.0) / speedup;
 
         return new PerformanceResult(baseTimeNs, optimizedTimeNs, speedup, efficiency);
     }

--- a/src/test/java/com/fft/optimized/PerformanceComparisonTest.java
+++ b/src/test/java/com/fft/optimized/PerformanceComparisonTest.java
@@ -20,6 +20,10 @@ public class PerformanceComparisonTest {
 
     private FFTFactory factory;
 
+    // Consumes transform output so the JIT cannot eliminate the benchmarked call as dead code.
+    @SuppressWarnings("unused")
+    private volatile double sink;
+
     @BeforeEach
     void setUp() {
         factory = new DefaultFFTFactory();
@@ -28,21 +32,24 @@ public class PerformanceComparisonTest {
     /**
      * Returns the best (minimum) wall-clock time over several batches of {@code iterations}
      * transforms. Taking the fastest batch rejects GC/scheduling outliers, so the
-     * base-vs-optimized ratio is stable instead of flaking under host load. These are
-     * coarse sanity checks; use the JMH harness for rigorous benchmarking.
+     * base-vs-optimized ratio is stable instead of flaking under host load. The transform
+     * output is accumulated into a volatile sink so the JIT cannot dead-code-eliminate the
+     * call. These are coarse sanity checks; use the JMH harness for rigorous benchmarking.
      */
     private long bestTransformNanos(FFT fft, double[] real, double[] imag, int iterations) {
+        double local = 0.0;
         for (int i = 0; i < WARMUP; i++) {
-            fft.transform(real, imag, true);
+            local += fft.transform(real, imag, true).getRealAt(0);
         }
         long best = Long.MAX_VALUE;
         for (int rep = 0; rep < MEASURE_REPEATS; rep++) {
             long start = System.nanoTime();
             for (int i = 0; i < iterations; i++) {
-                fft.transform(real, imag, true);
+                local += fft.transform(real, imag, true).getRealAt(0);
             }
             best = Math.min(best, System.nanoTime() - start);
         }
+        sink = local;
         return best;
     }
     
@@ -60,8 +67,9 @@ public class PerformanceComparisonTest {
         System.out.printf("FFT Size 8 - Base: %,d ns, Optimized: %,d ns, Speedup: %.2fx%n",
                          baseTime, optimizedTime, speedup);
 
-        // FFTOptimized8 is actually slower than base - reflect reality
-        assertThat(speedup).isGreaterThan(0.1); // FFTOptimized8 shows performance regression
+        // Conservative regression guard: the size-8 optimized impl must beat FFTBase.
+        // This is a coarse in-JVM check, not the canonical speedup figure (use JMH for that).
+        assertThat(speedup).isGreaterThan(1.1);
     }
     
     @Test
@@ -78,45 +86,25 @@ public class PerformanceComparisonTest {
         System.out.printf("FFT Size 16 - Base: %,d ns, Optimized: %,d ns, Speedup: %.2fx%n",
                          baseTime, optimizedTime, speedup);
 
-        // FFT16 has a dedicated optimized implementation; best-of-batches keeps the
-        // ratio stable, so it should be at least comparable to base.
-        assertThat(speedup).isGreaterThan(0.5);
+        // Conservative regression guard: the size-16 optimized impl must beat FFTBase.
+        // Coarse in-JVM check, not the canonical speedup figure (use JMH for that).
+        assertThat(speedup).isGreaterThan(1.1);
     }
     
     @Test
-    void compareFFT32Performance() {
-        double[] real = generateTestSignal(32);
-        double[] imag = new double[32];
-        FFTBase base = new FFTBase();
-        FFT optimized = factory.createFFT(32);
-
-        long baseTime = bestTransformNanos(base, real, imag, 10000);
-        long optimizedTime = bestTransformNanos(optimized, real, imag, 10000);
-
-        double speedup = (double) baseTime / optimizedTime;
-        System.out.printf("FFT Size 32 - Base: %,d ns, Optimized: %,d ns, Speedup: %.2fx%n",
-                         baseTime, optimizedTime, speedup);
-
-        // Size 32 uses the FFTBase fallback, allow some performance degradation
-        assertThat(speedup).isGreaterThan(0.1); // Very relaxed threshold for fallback implementation
+    void fft32UsesBaseFallback() {
+        // No size-32 optimized implementation exists, so factory.createFFT(32) returns the
+        // FFTBase fallback. A "base vs optimized" speedup would compare FFTBase to itself and
+        // measure nothing, so we assert the fallback instead. (Output correctness for size 32
+        // is covered by validateCorrectness.)
+        assertThat(factory.createFFT(32)).isInstanceOf(FFTBase.class);
     }
-    
+
     @Test
-    void compareFFT64Performance() {
-        double[] real = generateTestSignal(64);
-        double[] imag = new double[64];
-        FFTBase base = new FFTBase();
-        FFT optimized = factory.createFFT(64);
-
-        long baseTime = bestTransformNanos(base, real, imag, 5000);
-        long optimizedTime = bestTransformNanos(optimized, real, imag, 5000);
-
-        double speedup = (double) baseTime / optimizedTime;
-        System.out.printf("FFT Size 64 - Base: %,d ns, Optimized: %,d ns, Speedup: %.2fx%n",
-                         baseTime, optimizedTime, speedup);
-
-        // Size 64 uses the FFTBase fallback, allow some performance degradation
-        assertThat(speedup).isGreaterThan(0.1); // Very relaxed threshold for fallback implementation
+    void fft64UsesBaseFallback() {
+        // No size-64 optimized implementation exists: factory.createFFT(64) falls back to
+        // FFTBase, so there is no speedup to measure here.
+        assertThat(factory.createFFT(64)).isInstanceOf(FFTBase.class);
     }
     
     @Test

--- a/src/test/java/com/fft/regression/PerformanceRegressionTest.java
+++ b/src/test/java/com/fft/regression/PerformanceRegressionTest.java
@@ -1,7 +1,9 @@
 package com.fft.regression;
 
+import com.fft.core.FFTBase;
 import com.fft.core.FFTResult;
 import com.fft.core.TwiddleFactorCache;
+import com.fft.optimized.FFTOptimized8;
 import com.fft.utils.FFTUtils;
 import com.fft.utils.PitchDetectionUtils;
 import org.junit.jupiter.api.DisplayName;
@@ -90,31 +92,43 @@ class PerformanceRegressionTest {
     class FFTPerformanceBaselines {
 
         @Test
-        @DisplayName("Should maintain FFT8 speedup (target: 2.27x)")
+        @DisplayName("Should keep FFT8 optimized faster than FFTBase (conservative guard)")
         void shouldMaintainFFT8Speedup() {
-            double[] signal = FFTUtils.generateTestSignal(8, "random");
+            double[] real = FFTUtils.generateTestSignal(8, "random");
+            double[] imag = new double[8];
+            FFTBase base = new FFTBase();
+            FFTOptimized8 optimized = new FFTOptimized8();
 
-            // Warmup
-            warmup(() -> FFTUtils.fft(signal.clone()));
+            warmup(() -> base.transform(real, imag, true));
+            warmup(() -> optimized.transform(real, imag, true));
 
-            // Benchmark
-            long avgTime = benchmark(() -> FFTUtils.fft(signal.clone()));
+            long baseNanos = bestNanosPerOp(BENCHMARK_ITERATIONS,
+                () -> base.transform(real, imag, true).getRealAt(0));
+            long optimizedNanos = bestNanosPerOp(BENCHMARK_ITERATIONS,
+                () -> optimized.transform(real, imag, true).getRealAt(0));
 
-            // FFT8 should complete in reasonable time (< 10 microseconds)
-            assertThat(avgTime).isLessThan(10_000L); // 10 µs
+            double speedup = (double) baseNanos / optimizedNanos;
+            // Conservative regression guard (in-JVM, best-of-batches). The canonical speedup
+            // figure is measured separately with JMH; here we only assert the optimized path
+            // is genuinely faster, catching a catastrophic regression without flaking.
+            assertThat(speedup)
+                .as("FFT8 optimized should beat FFTBase")
+                .isGreaterThan(1.1);
         }
 
         @Test
-        @DisplayName("Should maintain FFT128 speedup (target: 1.42x)")
-        void shouldMaintainFFT128Speedup() {
+        @DisplayName("Should meet FFT128 latency budget (FFTBase fallback, no dedicated impl)")
+        void shouldMeetFFT128LatencyBudget() {
+            // Size 128 has no optimized implementation; it runs on FFTBase. This is an
+            // absolute-latency budget, not a speedup target.
             double[] signal = FFTUtils.generateTestSignal(128, "random");
 
-            warmup(() -> FFTUtils.fft(signal.clone()));
+            warmup(() -> FFTUtils.fft(signal));
 
-            long avgTime = benchmark(() -> FFTUtils.fft(signal.clone()));
+            long bestTime = bestNanosPerOp(BENCHMARK_ITERATIONS,
+                () -> FFTUtils.fft(signal).getRealAt(0));
 
-            // FFT128 should complete in reasonable time (< 50 microseconds)
-            assertThat(avgTime).isLessThan(50_000L); // 50 µs
+            assertThat(bestTime).isLessThan(50_000L); // 50 µs
         }
 
         @Test
@@ -122,12 +136,13 @@ class PerformanceRegressionTest {
         void shouldMaintainMediumSizePerformance() {
             double[] signal = FFTUtils.generateTestSignal(512, "random");
 
-            warmup(() -> FFTUtils.fft(signal.clone()));
+            warmup(() -> FFTUtils.fft(signal));
 
-            long avgTime = benchmark(() -> FFTUtils.fft(signal.clone()));
+            long bestTime = bestNanosPerOp(BENCHMARK_ITERATIONS,
+                () -> FFTUtils.fft(signal).getRealAt(0));
 
             // FFT512 should complete in reasonable time (< 200 microseconds)
-            assertThat(avgTime).isLessThan(200_000L); // 200 µs
+            assertThat(bestTime).isLessThan(200_000L); // 200 µs
         }
 
         @Test
@@ -135,12 +150,13 @@ class PerformanceRegressionTest {
         void shouldMaintainLargeSizePerformance() {
             double[] signal = FFTUtils.generateTestSignal(4096, "random");
 
-            warmup(() -> FFTUtils.fft(signal.clone()));
+            warmup(() -> FFTUtils.fft(signal));
 
-            long avgTime = benchmark(() -> FFTUtils.fft(signal.clone()));
+            long bestTime = bestNanosPerOp(BENCHMARK_ITERATIONS,
+                () -> FFTUtils.fft(signal).getRealAt(0));
 
             // FFT4096 should complete in reasonable time (< 2ms)
-            assertThat(avgTime).isLessThan(2_000_000L); // 2 ms
+            assertThat(bestTime).isLessThan(2_000_000L); // 2 ms
         }
     }
 
@@ -272,19 +288,20 @@ class PerformanceRegressionTest {
     class ComparativePerformanceTests {
 
         @Test
-        @DisplayName("Should show performance improvement for optimized sizes")
+        @DisplayName("Should scale sub-linearly from 128 to 256 (O(N log N))")
         void shouldShowOptimizedSizeImprovement() {
-            // Compare optimized size (128) vs larger size (256)
+            // Both 128 and 256 run on FFTBase (no dedicated impl); this checks O(N log N)
+            // scaling, not a speedup.
             double[] signal128 = FFTUtils.generateTestSignal(128, "random");
             double[] signal256 = FFTUtils.generateTestSignal(256, "random");
 
             warmup(() -> {
-                FFTUtils.fft(signal128.clone());
-                FFTUtils.fft(signal256.clone());
+                FFTUtils.fft(signal128);
+                FFTUtils.fft(signal256);
             });
 
-            long time128 = benchmark(() -> FFTUtils.fft(signal128.clone()));
-            long time256 = benchmark(() -> FFTUtils.fft(signal256.clone()));
+            long time128 = bestNanosPerOp(BENCHMARK_ITERATIONS, () -> FFTUtils.fft(signal128).getRealAt(0));
+            long time256 = bestNanosPerOp(BENCHMARK_ITERATIONS, () -> FFTUtils.fft(signal256).getRealAt(0));
 
             // 256-point should take less than 4x the time of 128-point
             // (O(N log N) complexity, so 2x size should be ~2.15x time)
@@ -300,8 +317,8 @@ class PerformanceRegressionTest {
 
             for (int i = 0; i < sizes.length; i++) {
                 double[] signal = FFTUtils.generateTestSignal(sizes[i], "random");
-                warmup(() -> FFTUtils.fft(signal.clone()));
-                times[i] = benchmark(() -> FFTUtils.fft(signal.clone()));
+                warmup(() -> FFTUtils.fft(signal));
+                times[i] = bestNanosPerOp(BENCHMARK_ITERATIONS, () -> FFTUtils.fft(signal).getRealAt(0));
             }
 
             // Verify rough O(N log N) scaling
@@ -338,13 +355,13 @@ class PerformanceRegressionTest {
         void shouldHaveEfficientResultCreation() {
             double[] signal = FFTUtils.generateTestSignal(256, "random");
 
-            warmup(() -> FFTUtils.fft(signal.clone()));
+            warmup(() -> FFTUtils.fft(signal));
 
-            long avgTime = benchmark(() -> FFTUtils.fft(signal.clone()));
+            long bestTime = bestNanosPerOp(BENCHMARK_ITERATIONS, () -> FFTUtils.fft(signal).getRealAt(0));
 
             // Total time should be dominated by computation, not allocation
             // (< 100 microseconds for 256-point FFT)
-            assertThat(avgTime).isLessThan(100_000L);
+            assertThat(bestTime).isLessThan(100_000L);
         }
     }
 
@@ -406,13 +423,13 @@ class PerformanceRegressionTest {
         void shouldDetectFFT8Regression() {
             double[] signal = FFTUtils.generateTestSignal(8, "random");
 
-            warmup(() -> FFTUtils.fft(signal.clone()));
+            warmup(() -> FFTUtils.fft(signal));
 
-            long avgTime = benchmark(() -> FFTUtils.fft(signal.clone()));
+            long bestTime = bestNanosPerOp(BENCHMARK_ITERATIONS, () -> FFTUtils.fft(signal).getRealAt(0));
 
             // FFT8 should maintain speedup (< 10 µs baseline)
             // If this fails, there's a performance regression
-            assertThat(avgTime)
+            assertThat(bestTime)
                 .as("FFT8 performance regression detected!")
                 .isLessThan(10_000L);
         }


### PR DESCRIPTION
## Summary
Refactored performance regression tests and benchmarks to use a best-of-batches measurement strategy instead of simple averaging. This eliminates flakiness caused by GC pauses and scheduling outliers, making performance assertions reliable under normal host load without requiring isolated test environments.

## Key Changes

- **Best-of-batches measurement**: Replaced single-run and simple-average timing with multiple measurement repeats, keeping only the fastest batch to reject GC/scheduling noise
- **Dead-code elimination prevention**: Added volatile `sink` field and consume transform output (`.getRealAt(0)`) in all benchmarks so the JIT cannot optimize away the benchmarked calls
- **Realistic speedup assertions**: Changed from absolute speedup targets (e.g., "2.27x") to conservative regression guards (e.g., ">1.1x") that catch catastrophic regressions without flaking
- **Clarified test intent**: Updated test names and comments to distinguish between:
  - Sizes with dedicated optimized implementations (8, 16) → measure speedup vs FFTBase
  - Sizes using FFTBase fallback (32+) → measure absolute latency budgets or O(N log N) scaling
- **Removed fallback comparisons**: Eliminated meaningless speedup tests for sizes 32 and 64 (which have no optimized impl), replacing with assertions that they correctly use FFTBase fallback

## Implementation Details

- `PerformanceRegressionTest`: Updated all baseline and comparative tests to use `bestNanosPerOp()` helper with `BENCHMARK_ITERATIONS` and consume output
- `FFTPerformanceBenchmarkTest`: Increased warmup from 50 to 2000 iterations, added `MEASURE_REPEATS=5` for best-of-batches, refactored `comparePerformance()` to time whole batches and keep minimum
- `PerformanceComparisonTest`: Added `bestTransformNanos()` helper using best-of-batches with output consumption; simplified size 32/64 tests to assert fallback behavior instead of measuring meaningless speedups

All assertions now use conservative thresholds (>1.1x for optimized sizes) that reflect real in-JVM measurement without flaking, while canonical speedup figures remain measured via JMH.

https://claude.ai/code/session_01KXxrbqJB9NGEqXFHqVFzoF

## Summary by Sourcery

Refine FFT performance regression and comparison tests to use stable best-of-batches timing while tightening and clarifying performance expectations for optimized vs fallback implementations.

Enhancements:
- Adopt best-of-batches timing helpers across regression and comparison tests to reduce flakiness from GC and scheduling noise.
- Ensure benchmarked FFT transforms consume their output via a volatile sink to prevent JIT dead-code elimination in performance tests.
- Tighten performance assertions so optimized FFT sizes must be measurably faster than FFTBase while fallback-only sizes use absolute latency or complexity-based guards instead of meaningless speedup checks.
- Clarify and update test names and comments to distinguish optimized sizes (8,16) from FFTBase fallback sizes (32+), and replace size 32/64 speedup tests with explicit fallback-behavior checks.

Tests:
- Increase warmup iterations and add repeated measurements in FFTPerformanceBenchmarkTest to stabilize speedup measurements and enforce conservative regression guards for optimized sizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced performance benchmark reliability with more robust timing measurements and multiple measurement batches to reduce scheduling and garbage collection noise.
  * Strengthened performance regression detection with refined measurement strategies and stricter performance thresholds.
  * Improved baseline performance tests for better optimization isolation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hedoluna/fft/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->